### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,70 @@
+## Dockerfile for devcontainer
+
+FROM mcr.microsoft.com/devcontainers/base:bookworm AS base
+
+ARG USER=vscode
+ARG GROUP=vscode
+
+ENV HOME="/home/${USER}"
+ENV PATH="$HOME/.cargo/bin:$PATH"
+
+# Install dependencies
+RUN apt-get update \
+    && apt-get -y install \
+        build-essential \
+        cmake \
+        curl \
+        gdb \
+        git \
+        gnupg \
+        lsb-release \
+        make \
+        pkg-config \
+        software-properties-common \
+        sudo \
+        wget \
+        musl-tools
+
+ARG LLVM_VERSION=18
+
+# Install llvm
+RUN wget https://apt.llvm.org/llvm.sh \
+    && chmod +x ./llvm.sh         \
+    && sudo ./llvm.sh ${LLVM_VERSION} clang clang-tools-extra      \
+    && sudo ln -s /usr/lib/llvm-${LLVM_VERSION}/bin/ld.lld /usr/bin/ld.lld     \
+    && sudo ln -s /usr/lib/llvm-${LLVM_VERSION}/bin/clang /usr/bin/clang
+
+# Install Node.js
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs
+
+FROM base AS dev
+
+# Make sure the devcontainer user has sudo access
+RUN chown -R "${USER}:${GROUP}" /home/${USER} \
+    && echo "${USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Persist bash history
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+    && mkdir /commandhistory \
+    && touch /commandhistory/.bash_history \
+    && chown -R "${USER}" /commandhistory \
+    && echo "$SNIPPET" >> "/home/${USER}/.bashrc"
+
+USER $USER
+
+ARG RUST_TOOLCHAIN=1.89
+
+# Install rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+    && rustup default ${RUST_TOOLCHAIN} \
+    && rustup target add x86_64-unknown-linux-gnu \
+    && rustup target add x86_64-unknown-linux-musl \
+    && rustup target add x86_64-unknown-none      \
+    && rustup target add wasm32-wasip1             \
+    && rustup toolchain add nightly-x86_64-unknown-linux-gnu \
+    && cargo install just \
+    && cargo install cargo-component \
+    && cargo install cargo-hyperlight \
+    && cargo install hyperlight-wasm-aot --locked --version 0.12.0 \
+    && cargo install wasmtime-cli --locked --version 36.0.6

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+  "name": "Hyperlight Wasm HTTP Example",
+
+  "image": "ghcr.io/hyperlight-dev/hyperlight-wasm-http-example-devcontainer:latest",
+
+  "containerUser": "vscode",
+  "containerEnv": {
+    "DEVICE": "/dev/kvm",
+    "REMOTE_USER": "vscode",
+    "REMOTE_GROUP": "vscode"
+  },
+
+  "runArgs": [
+    "--device=/dev/kvm"
+  ],
+
+  "postStartCommand": "bash .devcontainer/setup.sh",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "vadimcn.vscode-lldb",
+        "dbaeumer.vscode-eslint",
+        "bytecodealliance.starlingmonkey-debugger"
+      ],
+      "settings": {
+        "rust-analyzer.rustfmt.extraArgs": [
+          "+nightly"
+        ]
+      }
+    }
+  }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Change device ownership
+sudo chown -R $REMOTE_USER:$REMOTE_GROUP $DEVICE

--- a/.github/workflows/CreateDevcontainerImage.yml
+++ b/.github/workflows/CreateDevcontainerImage.yml
@@ -1,0 +1,67 @@
+name: Create and publish devcontainer Docker image
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - ".devcontainer/Dockerfile"
+      - ".github/workflows/CreateDevcontainerImage.yml"
+      - "rust-toolchain.toml"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-devcontainer
+  USER: vscode
+  GROUP: vscode
+  LLVM_VERSION: 18
+  RUST_TOOLCHAIN_DEFAULT: 1.89
+  RUST_TOOLCHAIN_FILE: rust-toolchain.toml
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Read Rust toolchain version from ${{ env.RUST_TOOLCHAIN_FILE }}
+        id: toolchain
+        run: |
+          version=$(cat ${{ env.RUST_TOOLCHAIN_FILE }} | sed -n '/\[toolchain\]/,/^\[/{/^\s*channel = /s/[^"]*"\([^"]*\)".*/\1/p}')
+          cat ${{ env.RUST_TOOLCHAIN_FILE }} | grep $version &> /dev/null \
+            && echo "RUST_TOOLCHAIN=${version}" >> "$GITHUB_OUTPUT" \
+            || echo "RUST_TOOLCHAIN=${{ env.RUST_TOOLCHAIN_DEFAULT }}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: ./.devcontainer
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            USER=${{ env.USER }}
+            GROUP=${{ env.GROUP }}
+            LLVM_VERSION=${{ env.LLVM_VERSION }}
+            RUST_TOOLCHAIN=${{ steps.toolchain.outputs.RUST_TOOLCHAIN }}

--- a/README.md
+++ b/README.md
@@ -101,3 +101,7 @@ JS:
 ```sh
 cargo run -- out/sample_wasi_http_js.aot
 ```
+
+## Try it yourself!
+
+[GitHub codespaces](https://codespaces.new/hyperlight-dev/hyperlight-wasm-http-example)


### PR DESCRIPTION
This PR adds a dev container to easily test.

This PR adds a workflow that creates and publishes a devcontainer to `ghcr.io/hyperlight-dev/hyperlight-wasm-http-example-devcontainer:latest`. The workflow is a duplicate of `hyperlight's` for now.
